### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.sample-java-spring-boot-app
+++ b/Dockerfile.sample-java-spring-boot-app
@@ -1,0 +1,10 @@
+FROM maven:3.6.3-jdk-11 AS build
+WORKDIR /app
+COPY . .
+RUN mvn clean package
+
+FROM openjdk:11-jre-slim
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO java-test
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: java-test
+
+sample-java-spring-boot-app:
+  defines: runnable
+  metadata:
+    name: sample-java-spring-boot-app
+    description: A Java Spring Boot web application.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    sample-java-spring-boot-app:
+      image: env-4477.registry.local/sample-java-spring-boot-app:main-cd9dd94
+      build: .
+      dockerfile: Dockerfile.sample-java-spring-boot-app
+  services:
+    http:
+      description: HTTP port for web application
+      container: sample-java-spring-boot-app
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - java-test/sample-java-spring-boot-app


### PR DESCRIPTION
# Containerization and Deployment Configuration for Java Spring Boot Application

## Dockerfile Creation and Service Mapping

- I created a Dockerfile for the Java Spring Boot web application located at `src/main/java/io/buildpacks/example/sample`.
- The application does not require any external services like databases.
- The Dockerfile sets up a Java environment, builds the application using Maven, and runs the application, exposing port 8080.

## Monk.io Configuration

- Added `monk.yaml` to define the Monk.io deployment configuration.
- Included a `MANIFEST` file to list all files containing Monk configurations.
- The configuration specifies that the service exposes port 8080 for HTTP traffic.
- No environment variables or connections to other services are required for this application.

## Instructions for Continuation

- The PR is complete and ready for merging.
- Upon merging, the application will be re-deployed on each subsequent push.
- No further actions are required unless additional services or configurations need to be added in the future.

The application is a standard Spring Boot web application that serves HTTP traffic on port 8080 and does not interact with external services or require environment-specific configurations. The containerization and deployment configuration are set up to reflect this simplicity.